### PR TITLE
add an element to set when iterate set

### DIFF
--- a/pycg/machinery/definitions.py
+++ b/pycg/machinery/definitions.py
@@ -148,7 +148,9 @@ class DefinitionManager(object):
                 # the name pointer of the definition we're currently iterating
                 current_name_pointer = current_def.get_name_pointer()
                 # iterate the names the current definition points to items
-                for name in current_name_pointer.get():
+                # for name in current_name_pointer.get():
+                for name in current_name_pointer.get().copy():
+
                     # get the name pointer of the points to name
                     if not self.defs.get(name, None):
                         continue


### PR DESCRIPTION
I am a student trying to use this library to analyze some projects. When I use pycg to analyze app.py from Flask, I found an error. I enter the source code and find that is because we add an element to the set when we iterate the set.
```
 ~/Documents/pyVirtual/lib/python3.8/site-packages/flask: pycg ./app.py
 Traceback (most recent call last):  
  File "/Users/yixuanyan/Documents/pyVirtual/bin/pycg", line 8, in module  
    sys.exit(main())  
  File "/Users/yixuanyan/Documents/pyVirtual/lib/python3.8/site-packages/pycg/__main__.py", line 79, in main
    cg.analyze()
  File "/Users/yixuanyan/Documents/pyVirtual/lib/python3.8/site-packages/pycg/pycg.py", line 168, in analyze
    self.def_manager.complete_definitions()
  File "/Users/yixuanyan/Documents/pyVirtual/lib/python3.8/site-packages/pycg/machinery/definitions.py", line 149, in complete_definitions
    for name in current_name_pointer.get():
RuntimeError: Set changed size during iteration
```
I change `current_name_pointer.get()` into `current_name_pointer.get().copy` , then it works
 

 

