### PR TITLE
Produce Call Graphs in Fasten Version 2 Format

### DIFF
--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -247,18 +247,20 @@ class Fasten(BaseFormatter):
                 elif node in external:
                     mod = external[node]
                     uris.append(self.namespace_map.get(self.to_external_uri(mod, node)))
-            if dst in external:
-                graph["externalCalls"].append([
-                    str(uris[0]),
-                    str(uris[1]),
-                    {}
-                ])
-            else:
-                graph["internalCalls"].append([
-                    str(uris[0]),
-                    str(uris[1]),
-                    {}
-                ])
+
+            if len(uris) == 2:
+                if dst in external:
+                    graph["externalCalls"].append([
+                        str(uris[0]),
+                        str(uris[1]),
+                        {}
+                    ])
+                else:
+                    graph["internalCalls"].append([
+                        str(uris[0]),
+                        str(uris[1]),
+                        {}
+                    ])
         return graph
 
     def generate(self):

--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -174,28 +174,26 @@ class Fasten(BaseFormatter):
                         namespace=namespace_uri,
                         metadata=dict(first=info['first'], last=info['last']))
                 self.namespace_map[namespace_uri] = unique
-
+        mods = self.add_superclasses(mods)
         return mods
 
-    def class_hiearchy(self):
-        hierarchy = {}
+    def add_superclasses(self, mods):
         for cls_name, cls in self.classes.items():
             cls_uri = self.namespace_map.get(self.to_uri(cls["module"], cls_name))
-            hierarchy[cls_uri] = []
+            mods[self.to_uri(cls["module"])]["namespaces"][cls_uri]["metadata"]["superClasses"] = []
             for parent in cls["mro"]:
                 if parent == cls_name:
                     continue
 
                 if self.classes.get(parent):
                     parent_uri = self.to_uri(self.classes[parent]["module"], parent)
-                    parent_uri = self.namespace_map.get(parent_uri, parent_uri)
                 else:
                     parent_mod = parent.split(".")[0]
                     parent_uri = self.to_external_uri(parent_mod, parent)
 
-                hierarchy[cls_uri].append(parent_uri)
+                mods[self.to_uri(cls["module"])]["namespaces"][cls_uri]["metadata"]["superClasses"].append(parent_uri)
 
-        return hierarchy
+        return mods
 
     def create_namespaces_map(self):
         namespaces_maps = [{}, {}]
@@ -249,8 +247,9 @@ class Fasten(BaseFormatter):
             "depset": self.find_dependencies(self.package),
             "version": self.version,
             "timestamp": self.timestamp,
-            "modules": self.get_modules(),
-            "cha": self.class_hiearchy(),
+            "modules": {
+                "internal": self.get_modules()
+            },
             "graph": self.get_graph(),
             "nodes": self.get_unique_and_increment()
         }

--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -208,7 +208,7 @@ class Fasten(BaseFormatter):
     def get_external_modules(self):
         mods = {}
         for modname, module in self.external_mods.items():
-            name = self.to_uri(modname)
+            name = self.to_external_uri(modname).split("/")[2]
             namespaces = module["methods"]
 
             mods[name] = {

--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -241,9 +241,10 @@ class Fasten(BaseFormatter):
         return graph
 
     def generate(self):
-        return {
+        cg= {
             "product": self.product,
             "forge": self.forge,
+            "nodes": None,
             "generator": "PyCG",
             "depset": self.find_dependencies(self.package),
             "version": self.version,
@@ -252,3 +253,5 @@ class Fasten(BaseFormatter):
             "cha": self.class_hiearchy(),
             "graph": self.get_graph()
         }
+        cg["nodes"] = self.get_unique_and_increment()
+        return cg

--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -209,7 +209,8 @@ class Fasten(BaseFormatter):
     def get_graph(self):
         graph = {
             "internalCalls": [],
-            "externalCalls": []
+            "externalCalls": [],
+            "resolvedCalls": []
         }
 
         internal, external = self.create_namespaces_map()
@@ -241,17 +242,15 @@ class Fasten(BaseFormatter):
         return graph
 
     def generate(self):
-        cg= {
+        return {
             "product": self.product,
             "forge": self.forge,
-            "nodes": None,
             "generator": "PyCG",
             "depset": self.find_dependencies(self.package),
             "version": self.version,
             "timestamp": self.timestamp,
             "modules": self.get_modules(),
             "cha": self.class_hiearchy(),
-            "graph": self.get_graph()
+            "graph": self.get_graph(),
+            "nodes": self.get_unique_and_increment()
         }
-        cg["nodes"] = self.get_unique_and_increment()
-        return cg

--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -217,6 +217,7 @@ class Fasten(BaseFormatter):
             }
 
             for namespace, info in namespaces.items():
+                # We avoid saving the external module as external method
                 if info['name'] != modname:
                     namespace_uri = self.to_external_uri(modname, info['name'])
 

--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -234,8 +234,9 @@ class Fasten(BaseFormatter):
                     ])
                 else:
                     graph["internalCalls"].append([
-                        uris[0],
-                        uris[1]
+                        str(uris[0]),
+                        str(uris[1]),
+                        {}
                     ])
         return graph
 

--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -42,7 +42,6 @@ class Fasten(BaseFormatter):
         self.version = version
         self.timestamp = timestamp
 
-
     def get_unique_and_increment(self):
         unique = self.unique
         self.unique += 1
@@ -176,6 +175,7 @@ class Fasten(BaseFormatter):
                         metadata=dict(first=info['first'], last=info['last']))
                 self.namespace_map[namespace_uri] = unique
         mods = self.add_superclasses(mods)
+
         return mods
 
     def add_superclasses(self, mods):
@@ -235,6 +235,7 @@ class Fasten(BaseFormatter):
         }
 
         internal, external = self.create_namespaces_map()
+
         for src, dst in self.edges:
             uris = []
             for node in [src, dst]:
@@ -260,7 +261,7 @@ class Fasten(BaseFormatter):
         return graph
 
     def generate(self):
-        return  {
+        return {
             "product": self.product,
             "forge": self.forge,
             "generator": "PyCG",
@@ -274,4 +275,3 @@ class Fasten(BaseFormatter):
             "graph": self.get_graph(),
             "nodes": self.get_unique_and_increment()
         }
-

--- a/pycg/tests/fasten_format_test.py
+++ b/pycg/tests/fasten_format_test.py
@@ -73,8 +73,8 @@ class FastenFormatTest(TestBase):
         self.assertEqual(output["depset"], [])
         self.assertEqual(output["version"], self.version)
         self.assertEqual(output["timestamp"], self.timestamp)
-        self.assertEqual(output["modules"], {})
-        self.assertEqual(output["graph"], {"internalCalls": [], "externalCalls": []})
+        self.assertEqual(output["modules"], {"internal": {}, "external": {} })
+        self.assertEqual(output["graph"], {"internalCalls": [], "externalCalls": [], "resolvedCalls": []})
 
     def test_uri(self):
         self.cg_generator.functions = ['mod1.mod2.myfunc']
@@ -177,12 +177,12 @@ class FastenFormatTest(TestBase):
             }
         }
 
-    def test_modules(self):
+    def test_internal_modules(self):
         internal_mods = self._get_internal_mods()
         self.cg_generator.internal_mods = internal_mods
 
         formatter = self.get_formatter()
-        modules = formatter.generate()["modules"]
+        modules = formatter.generate()["modules"]["internal"]
 
         # test that keys are URI formatted names
         key_uris = [formatter.to_uri(key) for key in internal_mods]

--- a/pycg/tests/fasten_format_test.py
+++ b/pycg/tests/fasten_format_test.py
@@ -19,7 +19,7 @@
 # under the License.
 #
 from base import TestBase
-from pprint import pprint
+
 from pycg import utils
 from pycg.formats.fasten import Fasten
 


### PR DESCRIPTION
## Description
This Pull Request aims to update the Version of the Call Graphs produced by PyCG on Fasten Format from [Version 1](https://github.com/fasten-project/fasten/wiki/Revision-Call-Graph-format#version-1-1) to [Version 2](https://github.com/fasten-project/fasten/wiki/Revision-Call-Graph-format#version-2-1), as described on the [Fasten Wiki](https://github.com/fasten-project/fasten/wiki/Revision-Call-Graph-format#python).
The methodology used to make the convertion stems from the [Fasten Call Graph Producer](https://github.com/fasten-project/pypi-tools/tree/master/cg-producer), which was previously used to make the convertion between the different formats, but we tried to develop the most optimal implementation.

## Motivation 
Since the whole Python Pipeline on Fasten Project depends on Call Graphs following the Version 2 format, it makes sense that PyCG directly produces them without having one extra [tool](https://github.com/fasten-project/pypi-tools/tree/master/cg-producer) as a mediator to make the convertion. Also, with this change the Call Graphs produced by PyCG can be directly stitched  through [PyCG Stitcher](https://github.com/fasten-project/pycg-stitch), since the Stitcher only supports Version 2 Call Graphs

## Testing
Adapted the Fasten format unit tests to support the new format.