### PR TITLE
Analyze only Python Files

### DIFF
--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -476,7 +476,7 @@ class ProcessingBase(ast.NodeVisitor):
 
         fname = self.import_manager.get_filepath(imp)
 
-        if not fname or not self.import_manager.get_mod_dir() in fname:
+        if not fname or not fname.endswith(".py") or not self.import_manager.get_mod_dir() in fname:
             return
 
         self.import_manager.set_current_mod(imp, fname)


### PR DESCRIPTION
Currently, in some python packages, PyCG tried to analyze submodule files which are shared library files (having .so file extension). A a result, the tool would yield a UnicodeDecodeError as it would not be able to decode those files, as also reported here: https://github.com/vitsalis/PyCG/issues/29

With this PR, we enable PyCG to analyze only submodule python files.

An example to reproduce the error and to test the fix that this PR introduces:
```
pip3 download cryptography==3.4.7 --no-deps
unzip cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl
python3 -m pycg --fasten  --package cryptography $(find cryptography -type f -name "*.py")   -o  package.json
``` 