### PR TITLE
FIX: Avoid (Re)Importing Used Modules

### DIFF
--- a/pycg/machinery/imports.py
+++ b/pycg/machinery/imports.py
@@ -153,8 +153,8 @@ class ImportManager(object):
         module_spec = importlib.util.find_spec(mod_name, package=package)
         if module_spec is None:
             return importlib.import_module(mod_name, package=package)
-        else:
-            return importlib.util.module_from_spec(module_spec)
+
+         return importlib.util.module_from_spec(module_spec)
 
     def handle_import(self, name, level):
         # We currently don't support builtin modules because they're frozen.

--- a/pycg/machinery/imports.py
+++ b/pycg/machinery/imports.py
@@ -150,7 +150,11 @@ class ImportManager(object):
             self.create_edge(mod_name)
             return sys.modules[mod_name]
 
-        return importlib.import_module(mod_name, package=package)
+        module_spec = importlib.util.find_spec(mod_name, package=package)
+        if module_spec is None:
+            return importlib.import_module(mod_name, package=package)
+        else:
+            return importlib.util.module_from_spec(module_spec)
 
     def handle_import(self, name, level):
         # We currently don't support builtin modules because they're frozen.


### PR DESCRIPTION
# Description

Currently, PyCG failed to produce a call graph of itself due to a bug.
More specifically, when executed in the source code of itself, it yielded an `AttributeError` as it could not resolve the `pycg.utils.constants `module.

The problem is located on line 153 on the following code block:
https://github.com/vitsalis/PyCG/blob/5d2506f79c09f6925a1af4983109c200e2110d0e/pycg/machinery/imports.py#L148-L153
More precisely, when PyCG encounters an import, it checks whether the imported module is part of the standard library installed locally (by checking if it exists in the `sys.modules` dictionary). If this is not the case, it imports the module and returns the module object which is later processed.

The problem is that for modules which are already imported this command will statically import them, meaning that the info of the initial module used from pycg will be lost. Later, if PyCG tries to use any functions of the module which is lost from memory, an exception will be raised as it will not be able to locate any method.

# Fix

To fix this, I added checking whether the module of the specific package exists. If this is the case, we return the existing  module object in order to continue the import handling. If this is not the case, we import the module.

# Testing

Tested on the source code of PyCG, and it succesfully produces the call graph. Also tested on 2 sample pypi packages and the json output is the same before and after this fix, meaning that no regression issues seem to be introduced.

# Aditional Context
### Minimal Example to Reproduce Issue
```
git clone https://github.com/vitsalis/PyCG.git
cd PyCG
pip3 install pycg
pycg  pycg/utils/constants.py  pycg/utils/__init__.py 
```

### Logs
```
pycg pycg/utils/constants.py  pycg/utils/__init__.py 
Traceback (most recent call last):
  File "/home/gdrosos/.local/bin/pycg", line 8, in <module>
    sys.exit(main())
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/__main__.py", line 79, in main
    cg.analyze()
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/pycg.py", line 157, in analyze
    self.class_manager, self.module_manager)
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/pycg.py", line 148, in do_pass
    processor.analyze()
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/processing/preprocessor.py", line 375, in analyze
    self.visit(ast.parse(self.contents, self.filename))
  File "/usr/lib/python3.6/ast.py", line 253, in visit
    return visitor(node)
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/processing/preprocessor.py", line 114, in visit_Module
    super().visit_Module(node)
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/processing/base.py", line 61, in visit_Module
    self.generic_visit(node)
  File "/usr/lib/python3.6/ast.py", line 261, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.6/ast.py", line 253, in visit
    return visitor(node)
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/processing/preprocessor.py", line 209, in visit_ImportFrom
    self.visit_Import(node, prefix=node.module, level=node.level)
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/processing/preprocessor.py", line 181, in visit_Import
    add_external_def(src_name, tgt_name)
  File "/home/gdrosos/.local/lib/python3.6/site-packages/pycg/processing/preprocessor.py", line 164, in add_external_def
    defi = self.def_manager.create(name, utils.constants.EXT_DEF)
AttributeError: module 'pycg.utils.constants' has no attribute 'EXT_DEF'
```
