### PR TITLE
Require Python 3.4 version or latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ In _43rd International Conference on Software Engineering, ICSE '21_,
 
 # Installation
 
-PyCG is implemented in Python3 and has no dependencies. Simply:
+PyCG is implemented in Python3 and requires Python version 3.4 or higher.
+It also has no dependencies. Simply:
 ```
 pip install pycg
 ```

--- a/pycg/machinery/imports.py
+++ b/pycg/machinery/imports.py
@@ -154,7 +154,7 @@ class ImportManager(object):
         if module_spec is None:
             return importlib.import_module(mod_name, package=package)
 
-         return importlib.util.module_from_spec(module_spec)
+        return importlib.util.module_from_spec(module_spec)
 
     def handle_import(self, name, level):
         # We currently don't support builtin modules because they're frozen.

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ def setup_package():
         license='Apache Software License',
         packages=find_packages(),
         install_requires=[],
+        python_requires='>=3.4',
         entry_points = {
             'console_scripts': [
                 'pycg=pycg.__main__:main',


### PR DESCRIPTION
# Description

* Following the fix of https://github.com/vitsalis/PyCG/pull/31, we need to configure PyCG to require a Python version greater or equal than 3.4, in order maintain the changes introduced.
* I also updated the project's readme in order to inform users regarding this additional requirement