### PR TITLE
Fix error when parsing PyPI Packages having erroneous requirements file

### DIFF
--- a/pycg/formats/fasten.py
+++ b/pycg/formats/fasten.py
@@ -87,8 +87,12 @@ class Fasten(BaseFormatter):
         for line in lines:
             if not line:
                 continue
-
-            req = Requirement.parse(line)
+            
+            try:
+                req = Requirement.parse(line)
+            except ValueError as e:
+                # The specific line in the requirements.txt does not follow the Requirements File Format
+                continue
 
             product = req.unsafe_name
             specs = req.specs


### PR DESCRIPTION
While using PyCG to produce the call graph of PyPI libraries, I noticed that for some packages PyCG was not able to produce the Call Graph in the Fasten format due to the following error: 
```
'Traceback (most recent call last):\n  File "/home/gdrosos/.local/bin/pycg", line 8, in <module>\n    sys.exit(main())\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg/__main__.py", line 87, in main\n    output = formatter.generate()\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg/formats/fasten.py", line 271, in generate\n    "depset": self.find_dependencies(self.package),\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg/formats/fasten.py", line 91, in find_dependencies\n    req = Requirement.parse(line)\n  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3139, in parse\n    req, = parse_requirements(s)\nValueError: not enough values to unpack (expected 1, got 0)\nCommand exited with non-zero status 1\nsecs=12.56\nmem=43460\n'
```
This happens because the requirements.txt file of some libraries like [rebulk](https://github.com/Toilal/rebulk/blob/develop/requirements.txt) include lines that cannot be parsed with the default `Requirements.parse()` method that PyCG uses. 

In order to tacke this issue, in case a ValueError occurs, instead of breaking PyCG we just ignore the specific line of the requirements file and continue towards parsing the remaining lines.