### PR TITLE
Fix Encoding Error when reading Files

### DIFF
--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -33,7 +33,7 @@ class ProcessingBase(ast.NodeVisitor):
 
         self.filename = os.path.abspath(filename)
 
-        with open(filename, "rt") as f:
+        with open(filename, "rt", errors='replace') as f:
             self.contents = f.read()
 
         self.name_stack = []


### PR DESCRIPTION
# Description
Some python source files that use a specific encoding  (e.g. iso8859-1) break PyCG due to a `UnicodeDecodeError` when reading their contents. 

In order to tackle this issue, when PyCG reads the contents of files during the Base Processing, we pass to the `open() `function the `errors` parameter the 'replace' value, which according to the `open()` [documentation](https://docs.python.org/3/library/functions.html#open) inserts a replacement marker (more specifically the question mark: '?') in the  malformed data that cause encoding and decoding errors. On this way we avoid breaking PyCG. 

We could also set the error handling name to `ignore`for simplicity, but  ignoring encoding errors can lead to data loss.

# Steps to Test
When trying to build the call graph of the version 4.5.4 of the coverage pypi library,  the error on PyCG occurs when  reading the contents of the `tests/farm/html/src/solatin1.py` file, and we recieve the following log:
```
{'product': 'coverage', 'version': '4.5.4', 'message': 'Traceback (most recent call last):\n  File "/home/gdrosos/.local/bin/pycg", line 33, in <module>\n    sys.exit(load_entry_point(\'pycg==0.0.6\', \'console_scripts\', \'pycg\')())\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg-0.0.6-py3.9.egg/pycg/__main__.py", line 79, in main\n    cg.analyze()\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg-0.0.6-py3.9.egg/pycg/pycg.py", line 155, in analyze\n    self.do_pass(PreProcessor, True,\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg-0.0.6-py3.9.egg/pycg/pycg.py", line 146, in do_pass\n    processor = cls(input_file, input_mod,\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg-0.0.6-py3.9.egg/pycg/processing/preprocessor.py", line 33, in __init__\n    super().__init__(filename, modname, modules_analyzed)\n  File "/home/gdrosos/.local/lib/python3.9/site-packages/pycg-0.0.6-py3.9.egg/pycg/processing/base.py", line 37, in __init__\n    self.contents = f.read()\n  File "/usr/lib/python3.9/codecs.py", line 322, in decode\n    (result, consumed) = self._buffer_decode(data, self.errors, final)\nUnicodeDecodeError: \'utf-8\' codec can\'t decode byte 0xd7 in position 238: invalid continuation byte\nCommand exited with non-zero status 1\nsecs=2.22\nmem=38588\n'}
```
