### PR TITLE
Reset counters only in existing class def scopes

### DIFF
--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -123,7 +123,8 @@ class ProcessingBase(ast.NodeVisitor):
     def visit_ClassDef(self, node):
         self.name_stack.append(node.name)
         self.method_stack.append(node.name)
-        self.scope_manager.get_scope(self.current_ns).reset_counters()
+        if self.scope_manager.get_scope(self.current_ns):
+            self.scope_manager.get_scope(self.current_ns).reset_counters()
         for stmt in node.body:
             self.visit(stmt)
         self.method_stack.pop()


### PR DESCRIPTION
# Description

When PyCG processes a new class definition, it tries to reset the counters of the scope within the namespace of the correspondoing class. In some cases, were a scope object has not been instantiated for a given namespace, the `reset_counters()` method is called upon a NoneType Object resulting in an AttributeError which breaks PyCG.
We adopted the  visit_ClassDef method to reset the counter of a corresponding namespace scope only when the specific scope exists.

# Steps to Test

Before this PR, having downloaded and unziped the  neuromation:20.12.7 pypi library, when running the

`pycg --package neuromation $(find neuromation  -type f -name "*.py") --fasten`
we used to get the following error

```
   ...
    File "/opt/homebrew/lib/python3.10/site-packages/pycg-0.0.6-py3.10.egg/pycg/processing/preprocessor.py", line 65, in analyze_submodule
    super().analyze_submodule(PreProcessor, modname,
  File "/opt/homebrew/lib/python3.10/site-packages/pycg-0.0.6-py3.10.egg/pycg/processing/base.py", line 485, in analyze_submodule
    visitor.analyze()
  File "/opt/homebrew/lib/python3.10/site-packages/pycg-0.0.6-py3.10.egg/pycg/processing/preprocessor.py", line 375, in analyze
    self.visit(ast.parse(self.contents, self.filename))
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py", line 410, in visit
    return visitor(node)
  File "/opt/homebrew/lib/python3.10/site-packages/pycg-0.0.6-py3.10.egg/pycg/processing/preprocessor.py", line 114, in visit_Module
    super().visit_Module(node)
  File "/opt/homebrew/lib/python3.10/site-packages/pycg-0.0.6-py3.10.egg/pycg/processing/base.py", line 61, in visit_Module
    self.generic_visit(node)
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py", line 418, in generic_visit
    self.visit(item)
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py", line 410, in visit
    return visitor(node)
  File "/opt/homebrew/lib/python3.10/site-packages/pycg-0.0.6-py3.10.egg/pycg/processing/preprocessor.py", line 368, in visit_ClassDef
    super().visit_ClassDef(node)
  File "/opt/homebrew/lib/python3.10/site-packages/pycg-0.0.6-py3.10.egg/pycg/processing/base.py", line 126, in visit_ClassDef
    self.scope_manager.get_scope(self.current_ns).reset_counters()
AttributeError: 'NoneType' object has no attribute 'reset_counters'
```