### PR TITLE
As graph output branch merged with master

### DIFF
--- a/pycg/machinery/imports.py
+++ b/pycg/machinery/imports.py
@@ -25,6 +25,8 @@ import importlib
 import copy
 
 from pycg import utils
+# Explicit import of abc is required in Python 3.10 https://github.com/grpc/grpc/issues/26062
+from importlib import abc
 
 def get_custom_loader(ig_obj):
     """

--- a/pycg/machinery/imports.py
+++ b/pycg/machinery/imports.py
@@ -21,19 +21,19 @@
 import sys
 import ast
 import os
-import importlib
 import copy
 
-from pycg import utils
-# Explicit import of abc is required in Python 3.10 https://github.com/grpc/grpc/issues/26062
+import importlib
 from importlib import abc
+
+from pycg import utils
 
 def get_custom_loader(ig_obj):
     """
     Closure which returns a custom loader
     that modifies an ImportManager object
     """
-    class CustomLoader(importlib.abc.SourceLoader):
+    class CustomLoader(abc.SourceLoader):
         def __init__(self, fullname, path):
             self.fullname = fullname
             self.path = path

--- a/pycg/tests/scopes_test.py
+++ b/pycg/tests/scopes_test.py
@@ -27,10 +27,11 @@ from pycg.machinery.scopes import ScopeManager, ScopeItem, ScopeError
 class ScopeManagerTest(TestBase):
     def test_handle_module(self):
         class MockTable(object):
-            def __init__(self, name, t, children=[]):
+            def __init__(self, name, t, children=[], lineno=0):
                 self.name = name
                 self.type = t
                 self.children = children
+                self.lineno = lineno
 
             def get_type(self):
                 return self.type
@@ -40,6 +41,9 @@ class ScopeManagerTest(TestBase):
 
             def get_children(self):
                 return self.children
+
+            def get_lineno(self):
+                return self.lineno
 
         grndchld1 = MockTable("grndchld1", "variable", [])
         grndchld2 = MockTable("grndchld2", "function", [])


### PR DESCRIPTION
This branch is updated with the latest commits on master. 

We are investigating how the assignment graph can be integrated in [Scalpel](https://github.com/SMAT-Lab/Scalpel). Therefore, it would be nice to have this API on the master branch of PyCG.

Furthermore, a few minor changes were added with commit [72a542f](https://github.com/vitsalis/PyCG/pull/53/commits/72a542fcc6bb08ec60cac1d922790fdd92ad003f) to make test cases pass. However, there is still a test case that is failing both on master and this branch. 

Python version: 3.10.6

The following errors with the test cases are fixed:

```
python3 -m unittest discover -s pycg/tests -p "*_test.py"
.............EF.E...........E
======================================================================
ERROR: test_custom_loader (imports_test.ImportsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./PyCG_main/pycg/tests/imports_test.py", line 128, in test_custom_loader
    loader = get_custom_loader(im)("node2", "filepath")
  File "./PyCG_main/pycg/machinery/imports.py", line 34, in get_custom_loader
    class CustomLoader(importlib.abc.SourceLoader):
AttributeError: module 'importlib' has no attribute 'abc'

======================================================================
ERROR: test_hooks (imports_test.ImportsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./PyCG_main/pycg/tests/imports_test.py", line 110, in test_hooks
    im.install_hooks()
  File "./PyCG_main/pycg/machinery/imports.py", line 207, in install_hooks
    loader = get_custom_loader(self)
  File "./PyCG_main/pycg/machinery/imports.py", line 34, in get_custom_loader
    class CustomLoader(importlib.abc.SourceLoader):
AttributeError: module 'importlib' has no attribute 'abc'

======================================================================
ERROR: test_handle_module (scopes_test.ScopeManagerTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./PyCG_main/pycg/tests/scopes_test.py", line 55, in test_handle_module
    items = sm.handle_module("root", "", "")
  File "./PyCG_main/pycg/machinery/scopes.py", line 55, in handle_module
    process(modulename, None, symtable.symtable(contents, filename, compile_type="exec"))
  File "./PyCG_main/pycg/machinery/scopes.py", line 34, in process
    if table.get_name() == 'top' and table.get_lineno() == 0:
AttributeError: 'MockTable' object has no attribute 'get_lineno'
```

The following test is still failing, any ideas what the issue is?

```
======================================================================
FAIL: test_handle_import (imports_test.ImportsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./PyCG_main/pycg/tests/imports_test.py", line 182, in test_handle_import
    mock_import.assert_called_once_with(".mod2", package="mod1")
  File "./PyCG/.env/lib/python3.10/site-packages/mock/mock.py", line 964, in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
  File "./PyCG/.env/lib/python3.10/site-packages/mock/mock.py", line 951, in assert_called_with
    raise AssertionError(_error_message()) from cause
AssertionError: expected call not found.
Expected: import_module('.mod2', package='mod1')
Actual: import_module('', package='mod1')
``` 