### PR TITLE
Catch an unhandled exception in Import Manager

### DIFF
--- a/pycg/machinery/imports.py
+++ b/pycg/machinery/imports.py
@@ -150,7 +150,11 @@ class ImportManager(object):
             self.create_edge(mod_name)
             return sys.modules[mod_name]
 
-        module_spec = importlib.util.find_spec(mod_name, package=package)
+        try:
+            module_spec = importlib.util.find_spec(mod_name, package=package)
+        except ModuleNotFoundError as a:
+            module_spec = None
+        
         if module_spec is None:
             return importlib.import_module(mod_name, package=package)
 


### PR DESCRIPTION
# Description

This PR aims to fix a regression bug caused by #31 

Precisely, during import handling, PyCG tries to capture the imported module object by testing some module & package name combinations.  When a combination is tested,  the absence of an exception indicates that the module objectwas returned succesfully. Consequently, PyCG exits the search. If an excpetion is raised, PyCG will test the next combination
https://github.com/vitsalis/PyCG/blob/ab75e4f8b53324f0be6fc4afaf53a39a0ee6a935/pycg/machinery/imports.py#L182-L187
In the `do_import` method,following the recent changes on #31, we check whether the imported module is part of the standard library installed locally (by checking if it exists in the `sys.modules` dictionary). If this is not the case, we check whether the module of the specific package exists.In this scenario, we return the existing module object in order to continue the import handling. Otherwise, we import the module. 
https://github.com/vitsalis/PyCG/blob/ab75e4f8b53324f0be6fc4afaf53a39a0ee6a935/pycg/machinery/imports.py#L148-L157

During this process, if an exception is raised PyCG will try the next combination. In the `do_import`  we use the `importlib.util.find_spec` function in order to check if the the module of the specific package exists. According to the [find_spec documentation](https://docs.python.org/3/library/importlib.html#importlib.util.find_spechttps://docs.python.org/3/library/importlib.html#importlib.util.find_spec), a `ModuleNotFoundError` will raise if the package is not in fact a package. In this case the expected behaviour for PyCG would be to try to import the module from the package. Instead, it tries the combination of package-module name since an expection is raised. 

This issue also causes the failling test  on `test_handle_import` reported  on #53, since the mocked package does not exist and an asserted method call is skipped, leading to the failling test

# Fix

In order to tackle the issue, we catch the ` ModuleNotFoundError ` within the `do_pass` method so that PyCG does not exit the iteration on this stage. On this way, the tests on `test_handle_import` are successfull.