### PR TITLE
Handle external module imports as package imports

### DIFF
--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -177,6 +177,15 @@ class PreProcessor(ProcessingBase):
                     )
 
         def add_external_def(name, target):
+            # In case we encounter an external import in the form of:
+            #  "import package.module.module...
+            # we want to treat it as: "import package" 
+            # and save it as such in the definition manager,
+            # so that we will be able to later map it
+            #  with its corresponding calls 
+            if (name == target) & (len(name.split(".")) > 1):
+                name = name.split(".")[0]
+                target = target.split(".")[0]
             # add an external def for the name
             defi = self.def_manager.get(name)
             if not defi:

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -179,10 +179,10 @@ class PreProcessor(ProcessingBase):
         def add_external_def(name, target):
             # In case we encounter an external import in the form of:
             #  "import package.module.module...
-            # we want to treat it as: "import package" 
+            # we want to treat it as: "import package"
             # and save it as such in the definition manager,
             # so that we will be able to later map it
-            #  with its corresponding calls 
+            #  with its corresponding calls
             if (name == target) & (len(name.split(".")) > 1):
                 name = name.split(".")[0]
                 target = target.split(".")[0]


### PR DESCRIPTION
## Description of the Problem

In python, we can directly import a module of an external package (dependency) using the command:
```python
import externalPackage.module
```
Moreover,  we can  call functions or classes within the aforementioned module by explicitly calling them using the  imported namespace:
```python
x= externalPackage.module.run()
```

When PyCG deals with those types of calls to external dependencies, we would expect that it would store the calls in the call graph.

Surprisingly, PyCG fails to store this call.
```
~ >>> pycg test.py
{"test": []}
```
In all other types of import e.g.
 ```python
#case1
 import externalPackage
x = externalPackage.module.run()
#case2
import  externalPackage.module as mod
x = mod.run()
#case3 
from externalPackage.module import run
x = run()
```
PyCG could store the call successfully:
```
~ >>> pycg test.py
{"test": ["externalPackage.module.run"], "externalPackage.module.run": []}
```

## Root Cause

When PyCG encounters an external definition when visiting an import statement during the pre-processing phase, 
it stores the local name assigned to the import statement (in our case `externalPackage.module`,
`externalPackage` in case 1, `mod` in case 2 and `run` in case 3) along with its definition object in a symbol table of the current scope.
https://github.com/vitsalis/PyCG/blob/a44940ed5769eae6b5f1274b2e788a14d0a4afc9/pycg/processing/preprocessor.py#L179-L192

Each scope has a symbol table that maps all variable names existing in the scope with their definition and has the following format:
```
{'test': <pycg.machinery.definitions.Definition object at 0x1006ca950>, 
'externalPackage1.module': <pycg.machinery.definitions.Definition object at 0x100c33820>,
'x': <pycg.machinery.definitions.Definition object at 0x101404d00>}
```

At a later phase, when PyCG encounters a variable reference, it uses the aforementioned symbol table to retrieve the definition for the current scope (in case it exists)
https://github.com/vitsalis/PyCG/blob/a44940ed5769eae6b5f1274b2e788a14d0a4afc9/pycg/processing/base.py#L204-L206
Therefore, when visiting the 
`externalPackage.module.run()` and more specifically when visiting the `externalPackage` (or) `module` variable during the AST, PyCG tries  to find their definition in the symbol table unsuccesfully, because the definition is linked to the   `externalPackage.module` key in the symbol table. Since PyCG cannot resolve the given variable name, it will not later store it in the call graph.

## Fix
To resolve this issue, this pull request introduces a quick fix: to treat external imports in the  afomentioned form as package imports e.g.  treat` import externalPackage.module` as`import externalPackage`.
On this way PyCG will be able to resolve the corresponding definition in the symbol table (since the key in the dictionary will be only `externalPackage`) and consequently identify the external call. Moreover, treating an external module import as package import will not affect the resulting call graph since an explicit module call can be performed on the same way in both cases.

## Implementation
The `add_external_def` method, recieves two arguments
*  the `name` attribute represents the fully qualified namespace to which the import is resolved. It provides the complete hierarchical path of the import. 
* The `target` attribute, on the other hand, refers to the local name assigned to the import within the current namespace. It specifies the name under which the imported module or package will be accessible in the current context.
If the attributes are equal (meaning that we have an import statement in the format of: `import something`) and if their namespace contains at least one dot (meaning that the import has the format of `import package.module`) then we keep only the package name from the namespace, and we use this value later to populate the symbol table.

The proposed changes specifically target the case where the imported name and target name are equal, and they consist of multiple modules. In such cases, the import statement is treated as a simplified "import package" statement. This ensures that the import is correctly saved and mapped in the definition manager, allowing for accurate resolution of its corresponding function calls at a later stage.

It's important to note that the proposed changes only affect the specific case of `import package.module.module....` Other forms of import statements are not impacted by these modifications.

## Test

For the minimal test case above:

```python
# test.py
import externalPackage.module
x= externalPackage.module.run()
```
Before the changes when we ran PyCG we would recieve an empty graph e.g.
```json
{"test": []}
```

After the changes we recieve:
```json
{"test": ["externalPackage.module.run"], "externalPackage.module.run": []}
```



