### PR TITLE
Add Support for Calls to External Class Instances

### DIFF
--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -216,7 +216,10 @@ class ProcessingBase(ast.NodeVisitor):
                     return_ns = utils.join_ns(
                         called_def.get_ns(), utils.constants.RETURN_NAME
                     )
-                elif called_def.get_type() == utils.constants.CLS_DEF or called_def.get_type() == utils.constants.EXT_DEF :
+                elif (
+                    called_def.get_type() == utils.constants.CLS_DEF
+                    or called_def.get_type() == utils.constants.EXT_DEF
+                ):
                     return_ns = called_def.get_ns()
                 defi = self.def_manager.get(return_ns)
                 if defi:

--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -216,7 +216,7 @@ class ProcessingBase(ast.NodeVisitor):
                     return_ns = utils.join_ns(
                         called_def.get_ns(), utils.constants.RETURN_NAME
                     )
-                elif called_def.get_type() == utils.constants.CLS_DEF:
+                elif called_def.get_type() == utils.constants.CLS_DEF or called_def.get_type() == utils.constants.EXT_DEF :
                     return_ns = called_def.get_ns()
                 defi = self.def_manager.get(return_ns)
                 if defi:


### PR DESCRIPTION
# Description of the Problem
Up until now, for python code in the form of:
```python
# test.py
import externalPackage
node = externalPackage.Class().instance_method()
```

PyCG would capture only the call to the external Class.
```json
{"test": ["externalPackage.Class"], "externalPackage.Class": []}
```
This incomplete call graph does not capture the external call to the class instance, resulting in limited analysis capabilities for code using external packages and their class instances.
An enriched call graph with all the external functions or classes called would also  significantly improve  the later stitching process with the `externalPackage`

## Root Cause
During the call graph processing [phase](https://github.com/vitsalis/PyCG/blob/main/pycg/processing/cgprocessor.py), when PyCG visits a call within the AST, it aims to find the actual namespace of the calls performed. The namespace provides the complete path or location of the function or class within the program's module structure. 
https://github.com/vitsalis/PyCG/blob/373751bb6bdf32516e23634ee4783be666f9e153/pycg/processing/cgprocessor.py#L143
**Note**: The calls might be more than one in cases like the following:
`package.Class().method().method()`


Then, for each identified call, if it is an external call PyCG will create an edge.

https://github.com/vitsalis/PyCG/blob/373751bb6bdf32516e23634ee4783be666f9e153/pycg/processing/cgprocessor.py#L158-L166

During the`retrieve_call_names` method  the  `_retrieve_attribute_names` is called to find the call name in the case of an attribute (a call in the form of `something.something`)
https://github.com/vitsalis/PyCG/blob/373751bb6bdf32516e23634ee4783be666f9e153/pycg/processing/base.py#L473-L474

Within the  `_retrieve_attribute_names`, we call the  `_retrieve_parent_names` in order to identify the parent namespace of a specific attribute node.
To adduce an example,
in the following attribute:
```python
 Class().instance_method()
```
the parent namespace of the attribute is `Class`
while on this example:
```python
x = Class()
x.instance_method()
```
the parent namespace of the  ` x.instance_method()` attribute is again `Class`

So in order to find the parent namespace (and consequently its definition)  we just decode the parent node 
https://github.com/vitsalis/PyCG/blob/373751bb6bdf32516e23634ee4783be666f9e153/pycg/processing/base.py#L313-L317 
The `decode_node` method is a very fundamental method which tries to find the definition stored in the symbol table of a corresponding AST node.
In our case e.g.
the `externalPackage.Class().instance_method()` call the parent node of the `.instance_method()`` which will be decoded is `externalPackage.Class()` which is instance of `ast.Call`

When decoding call nodes, PyCG tries to decode the node performing the call and based on the type of definition, it returns the correct namespace e.g. for functions it returns the return type. for classes it returns the namespace of the class (since it is a class instance).  But currently PyCG would ignore calls performed by nodes with external definitions, since it could not resolve for example the return type of such calls.


https://github.com/vitsalis/PyCG/blob/373751bb6bdf32516e23634ee4783be666f9e153/pycg/processing/base.py#L207-L225

## Proposed Change
To tackle the afforementioned issue, we handle  external definitions performing calls as internal classes performing calls, e.g. we return the namespace of the external node  performing the call. On this way all calls to external functions or classes are stored within the call graph. 

With this change, we store calls to external class instances in the call graph.  There are two types of such calls.
The first one, is a call in the form of `node = externalPackage.Class().instance_method()` which will be stored as
```json
{"test": ["externalPackage.Class", "externalPackage.Class.instance_method"], "externalPackage.Class": [], "externalPackage.Class.instance_method": []}
```
This wil be a sound representation which will lead to a sound stitching at a later stage.
The second one, is a call in the form of `node = externalPackage.method().instance_method()` were `method` is a function returning a class and the `instance_method` is an instance of the class returned by the  `method()`.
This call will be represented in the call graph as following:

```json
{"test": ["externalPackage.method", "externalPackage.method.instance_method"], "externalPackage.method": [], "externalPackage.method.instance_method": []}
```
This representation will not be sound, since the `externalPackage.method.instance_method ` is not the actual namespace of the `instance_method`, but PyCG cannot provide any additional insight on the returned class, and therefore the best it can do is to outsource the resolution for the stitching process.

**Note:**

With the proposed changes, all types of external calls can be handled:
Test Case 1
```python
import externalPackage
 externalPackage.Class().instance_method()
```
```json
{"test": ["externalPackage.Class.instance_method", "externalPackage.Class"], "externalPackage.Class": [], "externalPackage.Class.instance_method": []}
```
Test Case 2
```python
import externalPackage
 x = externalPackage.Class()
x.instance_method()
```
```json
{"test": ["externalPackage.Class.method.Class2.method2", "externalPackage.Class.method.Class2", "externalPackage.Class", "externalPackage.Class.method"], "externalPackage.Class": [], "externalPackage.Class.method": [], "externalPackage.Class.method.Class2": [], "externalPackage.Class.method.Class2.method2": []}
```
Test Case 3
```python
import externalPackage
 x = externalPackage.Class().method().Class2().method2()
```
```json
{"test": ["externalPackage.Class.method.Class2.method2", "externalPackage.Class.method.Class2", "externalPackage.Class", "externalPackage.Class.method"], "externalPackage.Class": [], "externalPackage.Class.method": [], "externalPackage.Class.method.Class2": [], "externalPackage.Class.method.Class2.method2": []}
```